### PR TITLE
Layout changes for mobile

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ languageCode = 'en_AU'
   image = "img/icapslogo.png" # Logo image. Path relative to "static"
   title = "The 35th International Conference" # Logo title, otherwise will use site title
   title2 = "on Automated Planning and Scheduling"
-  subtitle = "Melbourne, Victoria, Australia, November 9-14, 2025" # Logo subtitle
+  subtitle = "Melbourne, Victoria, Australia, \nNovember 9-14, 2025" # Logo subtitle
 
 [Params.style.vars]
      highlightColor = "#f5821f"

--- a/content/home/index.md
+++ b/content/home/index.md
@@ -11,10 +11,14 @@ draft: false
 <div id="ww_74a8a25ca6a11" v='1.3' loc='id' a='{"t":"responsive","lang":"en","sl_lpl":1,"ids":["wl2863"],"font":"Arial","sl_ics":"one_a","sl_sot":"celsius","cl_bkg":"image","cl_font":"#FFFFFF","cl_cloud":"#FFFFFF","cl_persp":"#81D4FA","cl_sun":"#FFC107","cl_moon":"#FFC107","cl_thund":"#FF5722"}'>More forecasts: <a href="https://oneweather.org/sydney/30_days/" id="ww_74a8a25ca6a11_u" target="_blank">Sydney 30 days weather forecast</a></div><script async src="https://app2.weatherwidget.org/js/?id=ww_74a8a25ca6a11"></script><br>
 -->
 
+<!-- Example banner image, the idea is to have images in the body rather than in the app bar. -->
+
+![Banner image](https://images.unsplash.com/photo-1514395462725-fb4566210144?q=80&w=2671&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D)
+
 The [International Conference on Automated Planning and
 Scheduling](https://www.icaps-conference.org) (ICAPS) is
 the premier forum for exchanging news and research results on the theory and
-applications of intelligent and automated planning and scheduling technology. 
+applications of intelligent and automated planning and scheduling technology.
 
 **ICAPS 2025** is the 35th edition of the ICAPS conference series and will take place in Melbourne, Victoria, Australia in November 2025. The conference will be co-located with the following events:
 
@@ -34,10 +38,9 @@ to:
 - Novel tools and frameworks for analysing and verifying the properties of systems executing plans, policies or schedules;
 - Studies of applying automated planning and scheduling technologies to significant problems with deep technical insight.
 
-The following video has been prepared by the Program Committee to walk interested parties through the major changes 
+The following video has been prepared by the Program Committee to walk interested parties through the major changes
 in the organisation of the conference with respect to previous editions:
 
 <div align="center">
  <iframe width="560" height="315" src="https://www.youtube.com/embed/4H9QyvOapek?si=3O7uiKJf5nylDLgn" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
-

--- a/themes/mainroad/assets/css/style.css
+++ b/themes/mainroad/assets/css/style.css
@@ -1,1024 +1,1027 @@
-	*,
-	*::before,
-	*::after {
-		box-sizing: border-box;
-	}
+@import url("https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 
-	article,
-	aside,
-	dialog,
-	figcaption,
-	figure,
-	footer,
-	header,
-	hgroup,
-	main,
-	nav,
-	section {
-		display: block;
-	}
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
 
-	:focus::-webkit-input-placeholder {
-		color: transparent;
-	}
+article,
+aside,
+dialog,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section {
+	display: block;
+}
 
-	:focus::-moz-placeholder {
-		color: transparent;
-	}
+:focus::-webkit-input-placeholder {
+	color: transparent;
+}
 
-	:focus:-moz-placeholder {
-		color: transparent;
-	}
+:focus::-moz-placeholder {
+	color: transparent;
+}
 
-	:focus:-ms-input-placeholder {
-		color: transparent;
-	}
+:focus:-moz-placeholder {
+	color: transparent;
+}
 
-	/* Structure */
-	html {
-		font-size: 100%;
-		-ms-text-size-adjust: none;
-		-webkit-text-size-adjust: none;
-	}
+:focus:-ms-input-placeholder {
+	color: transparent;
+}
 
-	body {
-		margin: 0;
-		font-family: "Open Sans", Helvetica, Arial, sans-serif;
-		font-size: 14px;
-		font-size: .875rem;
-		line-height: 1.6;
-		word-wrap: break-word;
-		background: #f7f7f7;
-		-webkit-font-smoothing: antialiased;
-	}
+/* Structure */
+html {
+	font-size: 100%;
+	-ms-text-size-adjust: none;
+	-webkit-text-size-adjust: none;
+}
 
-	.container {
-		position: relative;
-		width: 100%;
-		max-width: 1080px;
-		margin: 0 auto;
-	}
+body {
+	margin: 0;
+	font-family: "Inter", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	font-size: 0.875rem;
+	line-height: 1.6;
+	word-wrap: break-word;
+	background: #f7f7f7;
+	-webkit-font-smoothing: antialiased;
+}
 
-	.container--outer {
-		margin: 25px auto;
-		box-shadow: 0 0 10px rgba(50, 50, 50, .17);
-	}
+.container {
+	position: relative;
+	width: 100%;
+	max-width: 1080px;
+	margin: 0 auto;
+}
 
-	.wrapper {
-		padding: 25px;
-		background: #fff;
-	}
+.container--outer {
+	margin: 25px auto;
+	box-shadow: 0 0 10px rgba(50, 50, 50, 0.17);
+}
 
-	.flex {
-		display: -webkit-flex;
-		display: flex;
-	}
+.wrapper {
+	padding: 25px;
+	background: #fff;
+}
 
-	.primary {
-		-webkit-flex: 1 0 65.83%;
-		flex: 1 0 65.83%;
-		-webkit-order: 1;
-		order: 1;
-		min-width: 0;
-	}
+.flex {
+	display: -webkit-flex;
+	display: flex;
+}
 
-	.sidebar {
-		-webkit-flex: 1 0 31.66%;
-		flex: 1 0 31.66%;
-		-webkit-order: 2;
-		order: 2;
-		min-width: 0;
-		margin: 0 0 0 2.5%;
-	}
+.primary {
+	-webkit-flex: 1 0 65.83%;
+	flex: 1 0 65.83%;
+	-webkit-order: 1;
+	order: 1;
+	min-width: 0;
+}
 
-	.sidebar--left {
-		-webkit-order: 0;
-		order: 0;
-		margin: 0 2.5% 0 0;
-	}
+.sidebar {
+	-webkit-flex: 1 0 31.66%;
+	flex: 1 0 31.66%;
+	-webkit-order: 2;
+	order: 2;
+	min-width: 0;
+	margin: 0 0 0 2.5%;
+}
 
-	.clearfix {
-		display: block;
-	}
+.sidebar--left {
+	-webkit-order: 0;
+	order: 0;
+	margin: 0 2.5% 0 0;
+}
 
-	.clearfix::after {
-		display: block;
-		height: 0;
-		padding: 0;
-		margin: 0;
-		clear: both;
-		line-height: 0;
-		visibility: hidden;
-		content: "";
-	}
+.clearfix {
+	display: block;
+}
 
-	input,
-	button,
-	select,
-	optgroup,
-	textarea {
-		margin: 0;
-		font-family: inherit;
-		font-size: inherit;
-		line-height: inherit;
-	}
+.clearfix::after {
+	display: block;
+	height: 0;
+	padding: 0;
+	margin: 0;
+	clear: both;
+	line-height: 0;
+	visibility: hidden;
+	content: "";
+}
 
-	/* Button */
-	.btn {
-		padding: 5px 10px;
-		font-weight: 700;
-		color: #fff;
-		white-space: pre-line;
-		background: #2a2a2a;
-	}
+input,
+button,
+select,
+optgroup,
+textarea {
+	margin: 0;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+}
 
-	.btn:hover {
-		color: #fff;
-		background: #f5821f;
-	}
+/* Button */
+.btn {
+	padding: 5px 10px;
+	font-weight: 700;
+	color: #fff;
+	white-space: pre-line;
+	background: #2a2a2a;
+}
 
-	/* Animation */
-	.menu__item,
-	.btn {
-		transition: background-color .25s ease-out;
-	}
+.btn:hover {
+	color: #fff;
+	background: #f5821f;
+}
 
-	/* Typography */
-	h1,
-	h2,
-	h3,
-	h4,
-	h5,
-	h6 {
-		margin: 0 0 20px;
-		margin: 0 0 1.25rem;
-		font-weight: 700;
-		line-height: 1.3;
-		color: #000;
-	}
+/* Animation */
+.menu__item,
+.btn {
+	transition: background-color 0.25s ease-out;
+}
 
-    /* [ddh] 
+/* Typography */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	margin: 0 0 20px;
+	margin: 0 0 1.25rem;
+	font-weight: 550;
+	line-height: 1.3;
+	color: #000;
+}
+
+/* [ddh] 
      * The default heading size values are too big, in my opinion. So I
      * adjusted each one to the next smallest size, with h4=h5=h6
      * (theme default has h5=h6)
      */
-	h1 {
-        /* 
+h1 {
+	/* 
 		font-size: 32px;
 		font-size: 2rem;
         */
+	font-size: 24px;
+	font-size: 1.5rem;
+}
+
+h2 {
+	/*
 		font-size: 24px;
 		font-size: 1.5rem;
-	}
-
-	h2 {
-        /*
-		font-size: 24px;
-		font-size: 1.5rem;
         */
-		font-size: 20px;
-		font-size: 1.25rem;
-	}
+	font-size: 20px;
+	font-size: 1.25rem;
+}
 
-	h3 {
-        /*
+h3 {
+	/*
 		font-size: 20px;
 		font-size: 1.25rem;
         */
-        font-size: 18px;
-		font-size: 1.125rem;
-	}
+	font-size: 18px;
+	font-size: 1.125rem;
+}
 
-	h4 {
-		/*
+h4 {
+	/*
         font-size: 18px;
 		font-size: 1.125rem;
         */
-		font-size: 16px;
-		font-size: 1rem;
-	}
+	font-size: 16px;
+	font-size: 1rem;
+}
 
-	h5 {
-		font-size: 16px;
-		font-size: 1rem;
-	}
+h5 {
+	font-size: 16px;
+	font-size: 1rem;
+}
 
-	h6 {
-		font-size: 16px;
-		font-size: 1rem;
-	}
+h6 {
+	font-size: 16px;
+	font-size: 1rem;
+}
 
-	a {
-		color: #000;
-		text-decoration: none;
-	}
+a {
+	color: #000;
+	text-decoration: none;
+}
 
-	a:hover {
-		color: #f5821f;
-	}
+a:hover {
+	color: #f5821f;
+}
 
-	hr {
-		margin: 0 0 20px;
-		border: 0;
-		border-top: 1px solid #dadada;
-	}
+hr {
+	margin: 0 0 20px;
+	border: 0;
+	border-top: 1px solid #dadada;
+}
 
-	p {
-		margin: 0 0 20px;
-		margin: 0 0 1.25rem;
-	}
+p {
+	margin: 0 0 20px;
+	margin: 0 0 1.25rem;
+}
 
-	b,
-	strong {
-		font: inherit;
-		font-weight: 700;
-	}
+b,
+strong {
+	font: inherit;
+	font-weight: 700;
+}
 
-	i,
-	em {
-		font: inherit;
-		font-style: italic;
-	}
+i,
+em {
+	font: inherit;
+	font-style: italic;
+}
 
-	ol,
-	ul {
-		padding: 0;
-		margin: 0;
-	}
+ol,
+ul {
+	padding: 0;
+	margin: 0;
+}
 
-	small {
-		font-size: 12px;
-		font-size: .75rem;
-	}
+small {
+	font-size: 12px;
+	font-size: 0.75rem;
+}
 
-	mark {
-		background-color: #fd5;
-	}
+mark {
+	background-color: #fd5;
+}
 
-	figure {
-		margin: 0 0 20px;
-		margin: 0 0 1.25rem;
-	}
+figure {
+	margin: 0 0 20px;
+	margin: 0 0 1.25rem;
+}
 
-	figcaption {
-		margin-top: 4px;
-		margin-top: .25rem;
-		color: #666;
-	}
+figcaption {
+	margin-top: 4px;
+	margin-top: 0.25rem;
+	color: #666;
+}
 
-	figcaption h4 {
-		margin: 0;
-		color: inherit;
-	}
+figcaption h4 {
+	margin: 0;
+	color: inherit;
+}
 
-	pre,
-	code,
-	kbd,
-	samp {
-		font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+pre,
+code,
+kbd,
+samp {
+	font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+		"Courier New", monospace;
 
-		font-size: inherit;
-	}
+	font-size: inherit;
+}
 
-	pre,
-	code {
-		background-color: #f5f5f5;
-		border: 1px solid #ebebeb;
-	}
+pre,
+code {
+	background-color: #f5f5f5;
+	border: 1px solid #ebebeb;
+}
 
-	code {
-		padding: 0 5px;
-		color: #c33;
-	}
+code {
+	padding: 0 5px;
+	color: #c33;
+}
 
-	pre {
-		display: block;
-		padding: 0;
-		padding: 1.25rem;
-		margin-bottom: 20px;
-		margin-bottom: 1.25rem;
-		overflow: auto;
-		color: #000;
-	}
+pre {
+	display: block;
+	padding: 0;
+	padding: 1.25rem;
+	margin-bottom: 20px;
+	margin-bottom: 1.25rem;
+	overflow: auto;
+	color: #000;
+}
 
-	pre code {
-		padding: 0;
-		color: inherit;
-		white-space: inherit;
-		background: inherit;
-		border: 0;
-	}
+pre code {
+	padding: 0;
+	color: inherit;
+	white-space: inherit;
+	background: inherit;
+	border: 0;
+}
 
-	kbd {
-		padding: 2px 3px;
-		color: #fff;
-		background-color: #2a2a2a;
-	}
+kbd {
+	padding: 2px 3px;
+	color: #fff;
+	background-color: #2a2a2a;
+}
 
-	blockquote {
-		display: block;
-		padding: 5px 0 5px 15px;
-		margin: 0 0 20px;
-		margin: 0 0 1.25rem;
-		line-height: 1.6;
+blockquote {
+	display: block;
+	padding: 5px 0 5px 15px;
+	margin: 0 0 20px;
+	margin: 0 0 1.25rem;
+	line-height: 1.6;
 
-		border-left: 5px solid #f5821f;
+	border-left: 5px solid #f5821f;
+}
 
-	}
+blockquote p:last-child {
+	margin: 0;
+}
 
-	blockquote p:last-child {
-		margin: 0;
-	}
+blockquote footer {
+	text-align: right;
+}
 
-	blockquote footer {
-		text-align: right;
-	}
+sup,
+sub {
+	font-size: 10px;
+	font-size: 0.625rem;
+	font-style: normal;
+}
 
-	sup,
-	sub {
-		font-size: 10px;
-		font-size: .625rem;
-		font-style: normal;
-	}
+sup {
+	vertical-align: super;
+}
 
-	sup {
-		vertical-align: super;
-	}
+sub {
+	vertical-align: sub;
+}
 
-	sub {
-		vertical-align: sub;
-	}
+abbr[title] {
+	text-decoration: none;
+	cursor: help;
+	border-bottom: 1px dotted #000;
+}
 
-	abbr[title] {
-		text-decoration: none;
-		cursor: help;
-		border-bottom: 1px dotted #000;
-	}
+q {
+	font-style: italic;
+}
 
-	q {
-		font-style: italic;
-	}
+address {
+	margin-bottom: 20px;
+	margin-bottom: 1.25rem;
+	font-family: "Consolas", Courier New, Courier, monospace;
+	line-height: 1.5;
+}
 
-	address {
-		margin-bottom: 20px;
-		margin-bottom: 1.25rem;
-		font-family: "Consolas", Courier New, Courier, monospace;
-		line-height: 1.5;
-	}
+dl {
+	margin: 0 0 10px 20px;
+}
 
-	dl {
-		margin: 0 0 10px 20px;
-	}
+dt,
+dd {
+	display: list-item;
+}
 
-	dt,
-	dd {
-		display: list-item;
-	}
+dt {
+	font-weight: bold;
+	list-style-type: square;
+}
 
-	dt {
-		font-weight: bold;
-		list-style-type: square;
-	}
+dd {
+	margin-left: 20px;
+	list-style-type: circle;
+}
 
-	dd {
-		margin-left: 20px;
-		list-style-type: circle;
-	}
+select {
+	max-width: 100%;
+}
 
-	select {
-		max-width: 100%;
-	}
+.warning {
+	padding: 20px 10px;
+	text-align: center;
+	border: 1px solid #ddd;
+}
 
-	.warning {
-		padding: 20px 10px;
-		text-align: center;
-		border: 1px solid #ddd;
-	}
+.warning__icon {
+	margin-bottom: 20px;
+	fill: #ddd;
+}
 
-	.warning__icon {
-		margin-bottom: 20px;
-		fill: #ddd;
-	}
+/* Header */
+.header {
+	background: #fff;
+}
 
-	/* Header */
-	.header {
-		background: #fff;
-	}
+.logo {
+	padding: 25px;
+}
 
-	.logo {
-		padding: 25px;
-	}
+.logo__link {
+	display: inline-block;
+}
 
-	.logo__link {
-		display: inline-block;
-	}
+.logo__item {
+	display: inline-block;
+	vertical-align: middle;
+}
 
-	.logo__item {
-		display: inline-block;
-		vertical-align: middle;
-	}
+.logo__img {
+	max-height: 256px;
+	background-color: rgba(255, 255, 255, 0.75);
+}
 
-	.logo__img {
-		max-height: 256px;
-		background-color: rgba(255, 255, 255, 0.75);
-	}
-
-	.logo__text {
-		/* text-transform: uppercase; */
-        /* [ddh] adds a coloured element behind the logo;
+.logo__text {
+	/* text-transform: uppercase; */
+	/* [ddh] adds a coloured element behind the logo;
          * makes the logo text readable */
-		background-color: rgba(255, 255, 255, 0.75);
-	}
+	background-color: rgba(255, 255, 255, 0.75);
+}
 
-	.logo--mixed .logo__item {
-		margin: .5rem auto;
-	}
+.logo--mixed .logo__item {
+	margin: 0.5rem auto;
+}
 
-	.logo--mixed .logo__img {
-		max-width: 140px;
-		max-height: 140px;
-        padding:1.5px;
-	}
+.logo--mixed .logo__img {
+	max-width: 140px;
+	max-height: 140px;
+	padding: 1.5px;
+}
 
-	.logo--mixed .logo__text {
-		padding: 0 1rem;
-	}
+.logo--mixed .logo__text {
+	padding: 0 1rem;
+}
 
-	.logo__title {
-		font-size: 20px;
-		font-size: 1.8rem;
-		font-weight: 700;
-		line-height: 1;
-		color: rgba(35,31,32,1);
-		/*rgba(245,130,31,0.85);*/
-	}
+.logo__title {
+	font-size: 20px;
+	font-size: 1.8rem;
+	font-weight: 700;
+	line-height: 1;
+	color: rgba(35, 31, 32, 1);
+	/*rgba(245,130,31,0.85);*/
+}
 
-	.logo__tagline {
-		display: inline-block;
-		padding-top: 10px;
-		margin-top: 10px;
-		font-size: 14px;
-		font-size: .875rem;
-		font-weight: 700;
-		line-height: 1;
-		color: rgba(35,31,32,1);
-        /* [ddh] adjust the color of the divider between the 
+.logo__tagline {
+	display: inline-block;
+	padding-top: 10px;
+	margin-top: 10px;
+	font-size: 14px;
+	font-size: 0.875rem;
+	font-weight: 700;
+	line-height: 1;
+	color: rgba(35, 31, 32, 1);
+	/* [ddh] adjust the color of the divider between the 
          * $logoTitle2 text (=xx ICAPS)  and the logoSubtitle
          * (= location) 
          */
-		border-top: 1px solid rgba(35,31,32,1);
-	}
+	border-top: 1px solid rgba(35, 31, 32, 1);
+}
 
-	.divider {
-		height: 5px;
-		margin: 0;
+.divider {
+	height: 5px;
+	margin: 0;
 
-		background: #f5821f;
+	background: #f5821f;
 
-		border: 0;
-	}
+	border: 0;
+}
 
-	/* Main menu */
-	.no-js .menu__btn {
-		display: none;
+/* Main menu */
+.no-js .menu__btn {
+	display: none;
+}
+
+.menu__btn {
+	display: block;
+	width: 100%;
+	padding: 0;
+	font: inherit;
+	color: #fff;
+	background: #2a2a2a;
+	border: 0;
+	outline: 0;
+}
+
+.menu__btn-title {
+	position: relative;
+	display: block;
+	padding: 10px 15px;
+	padding: 0.625rem 0.9375rem;
+	font-weight: 700;
+	text-align: right;
+	text-transform: uppercase;
+	cursor: pointer;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
+}
+
+:focus > .menu__btn-title {
+	box-shadow: inset 0 0 1px 3px #f5821f;
+}
+
+button:not(:-moz-focusring):focus > .menu__btn-title {
+	box-shadow: none;
+}
+
+.menu__btn:focus,
+.menu__btn-title:focus {
+	outline: 0;
+}
+
+.js .menu__btn--active {
+	color: #f5821f;
+}
+
+.menu__list {
+	list-style: none;
+	background: #2a2a2a;
+}
+
+.menu__item:hover {
+	background: #f5821f;
+}
+
+.menu__item:first-child {
+	border: 0;
+}
+
+.menu__item--active {
+	background: #f5821f;
+}
+
+.menu__link {
+	display: block;
+	padding: 10px 15px;
+	padding: 0.625rem 0.9375rem;
+	font-weight: 700;
+	color: #fff;
+	text-transform: uppercase;
+}
+
+.menu__link:hover {
+	color: #fff;
+}
+
+.js .menu__list {
+	position: absolute;
+	z-index: 1;
+	width: 100%;
+	visibility: hidden;
+	-webkit-transform: scaleY(0);
+	transform: scaleY(0);
+	-webkit-transform-origin: top left;
+	transform-origin: top left;
+}
+
+.js .menu__list--active {
+	visibility: visible;
+	border-top: 1px solid rgba(255, 255, 255, 0.1);
+	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+	-webkit-transform: scaleY(1);
+	transform: scaleY(1);
+}
+
+.menu__list--transition {
+	transition: visibility 0.15s ease, transform 0.15s ease,
+		-webkit-transform 0.15s ease;
+}
+
+#banner-main {
+	background-image: url("/img/banner_crop.jpg");
+	background-attachment: fixed;
+	background-repeat: no-repeat;
+	background-position: center 0em;
+	background-size: 1080px;
+}
+
+@media screen and (min-width: 767px) {
+	.menu {
+		border-bottom: 5px solid #f5821f;
 	}
 
 	.menu__btn {
-		display: block;
-		width: 100%;
-		padding: 0;
-		font: inherit;
-		color: #fff;
-		background: #2a2a2a;
-		border: 0;
-		outline: 0;
+		display: none;
 	}
 
-	.menu__btn-title {
-		position: relative;
-		display: block;
-		padding: 10px 15px;
-		padding: .625rem .9375rem;
-		font-weight: 700;
-		text-align: right;
-		text-transform: uppercase;
-		cursor: pointer;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		-o-user-select: none;
-		user-select: none;
-	}
-
-	:focus>.menu__btn-title {
-		box-shadow: inset 0 0 1px 3px #f5821f;
-	}
-
-	button:not(:-moz-focusring):focus>.menu__btn-title {
-		box-shadow: none;
-	}
-
-	.menu__btn:focus,
-	.menu__btn-title:focus {
-		outline: 0;
-	}
-
-	.js .menu__btn--active {
-		color: #f5821f;
-
-	}
-
-	.menu__list {
-		list-style: none;
-		background: #2a2a2a;
-	}
-
-	.menu__item:hover {
-		background: #f5821f;
-
-	}
-
-	.menu__item:first-child {
-		border: 0;
-	}
-
-	.menu__item--active {
-		background: #f5821f;
-
-	}
-
-	.menu__link {
-		display: block;
-		padding: 10px 15px;
-		padding: .625rem .9375rem;
-		font-weight: 700;
-		color: #fff;
-		text-transform: uppercase;
-	}
-
-	.menu__link:hover {
-		color: #fff;
-	}
-
+	.menu__list,
 	.js .menu__list {
-		position: absolute;
-		z-index: 1;
-		width: 100%;
-		visibility: hidden;
-		-webkit-transform: scaleY(0);
-		transform: scaleY(0);
-		-webkit-transform-origin: top left;
-		transform-origin: top left;
-	}
-
-	.js .menu__list--active {
+		position: relative;
+		display: -webkit-flex;
+		display: flex;
+		-webkit-flex-wrap: wrap;
+		flex-wrap: wrap;
 		visibility: visible;
-		border-top: 1px solid rgba(255, 255, 255, .1);
-		border-bottom: 1px solid rgba(255, 255, 255, .1);
-		-webkit-transform: scaleY(1);
-		transform: scaleY(1);
-	}
-
-	.menu__list--transition {
-		transition: visibility .15s ease, transform .15s ease, -webkit-transform .15s ease;
-	}
-
-	@media screen and (min-width: 767px) {
-		.menu {
-			border-bottom: 5px solid #f5821f;
-
-		}
-
-		.menu__btn {
-			display: none;
-		}
-
-		.menu__list,
-		.js .menu__list {
-			position: relative;
-			display: -webkit-flex;
-			display: flex;
-			-webkit-flex-wrap: wrap;
-			flex-wrap: wrap;
-			visibility: visible;
-			border: 0;
-			-webkit-transform: none;
-			transform: none;
-		}
-
-		.menu__item {
-			border-left: 1px solid rgba(255, 255, 255, .1);
-		}
-	}
-
-	/* Posts/Pages */
-	.post__header,
-	.main__header {
-		margin-bottom: 20px;
-		margin-bottom: 1.25rem;
-	}
-
-	.main__title {
-		font-size: 28px;
-		font-size: 1.75rem;
-	}
-
-	.main__content {
-		margin-bottom: 20px;
-		margin-bottom: 1.25rem;
-	}
-
-	.meta {
-		font-size: 13px;
-		font-size: .8125rem;
-		vertical-align: baseline;
-	}
-
-	.meta,
-	.meta a {
-		color: #666;
-	}
-
-	.meta a:hover {
-		color: #f5821f;
-
-	}
-
-	.meta__item {
-		display: inline;
-		margin-left: 15px;
-	}
-
-	.meta__item:first-child {
-		margin-left: 0;
-	}
-
-	.meta__icon {
-		margin-right: 5px;
-		vertical-align: middle;
-		fill: #c4c4c4;
-	}
-
-	.meta__text {
-		vertical-align: middle;
-	}
-
-	.post__title {
-		margin: 0;
-	}
-
-	.post__meta {
-		padding: 5px 0;
-		margin-top: 10px;
-		margin-top: .625rem;
-		border-top: 1px dotted #ebebeb;
-		border-bottom: 1px dotted #ebebeb;
-	}
-
-	.post__lead {
-		margin-top: 4px;
-		margin-top: .25rem;
-		margin-bottom: 0;
-		font-size: 16px;
-		font-size: 1rem;
-		font-style: italic;
-	}
-
-	.post__thumbnail {
-		max-width: 1030px;
-		margin: 0 0 20px;
-		margin-bottom: 0 0 1.25rem;
-	}
-
-	.post__thumbnail img {
-		width: 100%;
-	}
-
-	.content a,
-	.warning a,
-	.authorbox__description a {
-			color: #f5821f;
-
-	}
-
-	.content a:hover,
-	.warning a:hover,
-	.authorbox__description a:hover {
-		color: #f5821f;
-		text-decoration: underline;
-	}
-
-	.content .alignnone {
-		display: block;
-		margin: 20px 0;
-		margin: 1.25rem 0;
-	}
-
-	.content .aligncenter {
-		display: block;
-		margin: 20px auto;
-		margin: 1.25rem auto;
-	}
-
-	.content .alignleft {
-		display: inline;
-		float: left;
-		margin: 5px 20px 20px 0;
-		margin: .3125rem 1.25rem 1.25rem 0;
-	}
-
-	.content .alignright {
-		display: inline;
-		float: right;
-		margin: 5px 0 20px 20px;
-		margin: .3125rem 0 1.25rem 1.25rem;
-	}
-
-	.content ul {
-		list-style: square;
-	}
-
-	.content ol {
-		list-style: decimal;
-	}
-
-	.content ul,
-	.content ol {
-		margin: 0 0 20px 40px;
-	}
-
-	.content ul ul,
-	.content ol ol,
-	.content ol ul,
-	.content ul ol {
-		margin: 0 0 0 40px;
-	}
-
-	.content li {
-		margin-bottom: 5px;
-	}
-
-	.post__footer {
-		margin-top: 20px;
-		margin-top: 1.25rem;
-	}
-
-	/* Post tags */
-	.tags {
-		margin-bottom: 20px;
-		margin-bottom: 1.25rem;
-		font-size: 12px;
-		font-size: .75rem;
-		line-height: 1;
-		color: #fff;
-	}
-
-	.tags__list {
-		list-style: none;
-	}
-
-	.tags__item {
-		float: left;
-		margin: 0 6px 6px 0;
-		margin: 0 .375rem .375rem 0;
-		text-transform: uppercase;
-		background: #2a2a2a;
-	}
-
-	.tags__item:hover {
-		background: #f5821f;
-
-	}
-
-	.tags__link,
-	.tags__link:hover {
-		display: block;
-		padding: 10px 15px;
-	}
-
-	.tags__badge {
-		float: left;
-		width: 32px;
-		height: 32px;
-		padding: 8px;
-		margin-right: 6px;
-
-		background: #f5821f;
-
-		fill: #fff;
-	}
-
-	/* Table of Contents */
-	.toc {
-		margin-bottom: 20px;
-		font-weight: 700;
-		color: #7a8288;
-		background: #fff;
-		border-color: #ebebeb;
-		border-style: solid;
-		border-top-width: 1px;
-		border-right-width: 1px;
-		border-bottom-width: 0;
-		border-left-width: 1px;
-	}
-
-	.toc__title {
-		padding: 5px 10px;
-		color: #fff;
-		text-transform: uppercase;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		-o-user-select: none;
-		user-select: none;
-		background: #2a2a2a;
-	}
-
-	.toc__menu ul {
-		margin: 0;
-		list-style: none;
-	}
-
-	.toc__menu li li a {
-		padding-left: 25px;
-	}
-
-	.toc__menu li li li a {
-		padding-left: 45px;
-	}
-
-	.toc__menu li li li li a {
-		padding-left: 65px;
-	}
-
-	.toc__menu li li li li li a {
-		padding-left: 85px;
-	}
-
-	.toc__menu li li li li li li a {
-		padding-left: 105px;
-	}
-
-	.toc__menu li {
-		margin: 0;
-	}
-
-	.toc__menu a {
-		display: block;
-		padding: 5px 10px;
-
-		color: #f5821f;
-
-		border-bottom: 1px solid #ebebeb;
-	}
-
-	.toc__menu a:hover {
-		text-decoration: underline;
-	}
-
-	/* Author Box */
-	.authorbox {
-		padding: 25px 0;
-		margin-bottom: 25px;
-		line-height: 1.5;
-		border-top: 1px solid #ebebeb;
-		border-bottom: 1px solid #ebebeb;
-	}
-
-	.authorbox__avatar {
-		float: left;
-		padding: 3px;
-		margin: 0 25px 0 0;
-		border: 1px solid #ebebeb;
-	}
-
-	.authorbox__header {
-		margin-bottom: 10px;
-	}
-
-	.authorbox__name {
-		font-size: 16px;
-		font-size: 1rem;
-		font-weight: 700;
-	}
-
-	/* List content */
-	.list__item {
-		padding-bottom: 20px;
-		padding-bottom: 1.25rem;
-		margin-bottom: 20px;
-		margin-bottom: 1.25rem;
-		border-bottom: 1px solid #ebebeb;
-	}
-
-	.list__header {
-		margin-bottom: 10px;
-		margin-bottom: .625rem;
-	}
-
-	.list__title {
-		font-size: 20px;
-		font-size: 1.25rem;
-	}
-
-	.list__meta {
-		margin-top: 5px;
-	}
-
-	.list__thumbnail {
-		float: left;
-		margin: 0 20px 0 0;
-	}
-
-	.list__thumbnail img {
-		width: 100%;
-		max-width: 235px;
-	}
-
-	.list__footer-readmore {
-		float: right;
-		margin-top: 10px;
-	}
-
-	/* Pagination */
-	.pagination {
-		margin-top: 20px;
-	}
-
-	.pagination__item {
-		display: inline-block;
-		padding: 10px 15px;
-		font-weight: 700;
-		color: #000;
-		background: #f5f5f5;
-	}
-
-	.pagination__item:hover,
-	.pagination__item--current {
-		color: #fff;
-
-		background: #f5821f;
-
-	}
-
-	/* Pager (prev/next links) navigation */
-	.pager {
-		-webkit-justify-content: space-between;
-		justify-content: space-between;
-		padding-top: 25px;
-		padding-bottom: 25px;
-		margin-bottom: 25px;
-		border-bottom: 1px solid #ebebeb;
-	}
-
-	.pager__subtitle {
-		display: block;
-		margin-bottom: 5px;
-		font-weight: 700;
-		line-height: 1;
-		text-transform: uppercase;
-	}
-
-	.pager__title {
-		margin-bottom: 0;
-		overflow: hidden;
-		font-size: 13px;
-		font-size: .8125rem;
-	}
-
-	.pager__item {
-		-webkit-flex: 1 1 50%;
-		flex: 1 1 50%;
-		max-width: 48%;
-	}
-
-	.pager__item--next {
-		margin-left: auto;
-		text-align: right;
-	}
-
-	.pager__link {
-		display: block;
-	}
-
-	/* Images / Video */
-	img {
-		width: auto\9;
-		/* ie8 */
-		max-width: 100%;
-		height: auto;
-		vertical-align: bottom;
-	}
-
-	iframe,
-	embed,
-	object,
-	video {
-		max-width: 100%;
-	}
-
-	/* Table */
-	/*table {
+		border: 0;
+		-webkit-transform: none;
+		transform: none;
+	}
+
+	.menu__item {
+		border-left: 1px solid rgba(255, 255, 255, 0.1);
+	}
+}
+
+/* Posts/Pages */
+.post__header,
+.main__header {
+	margin-bottom: 20px;
+	margin-bottom: 1.25rem;
+}
+
+.main__title {
+	font-size: 28px;
+	font-size: 1.75rem;
+}
+
+.main__content {
+	margin-bottom: 20px;
+	margin-bottom: 1.25rem;
+}
+
+.meta {
+	font-size: 13px;
+	font-size: 0.8125rem;
+	vertical-align: baseline;
+}
+
+.meta,
+.meta a {
+	color: #666;
+}
+
+.meta a:hover {
+	color: #f5821f;
+}
+
+.meta__item {
+	display: inline;
+	margin-left: 15px;
+}
+
+.meta__item:first-child {
+	margin-left: 0;
+}
+
+.meta__icon {
+	margin-right: 5px;
+	vertical-align: middle;
+	fill: #c4c4c4;
+}
+
+.meta__text {
+	vertical-align: middle;
+}
+
+.post__title {
+	margin: 0;
+}
+
+.post__meta {
+	padding: 5px 0;
+	margin-top: 10px;
+	margin-top: 0.625rem;
+	border-top: 1px dotted #ebebeb;
+	border-bottom: 1px dotted #ebebeb;
+}
+
+.post__lead {
+	margin-top: 4px;
+	margin-top: 0.25rem;
+	margin-bottom: 0;
+	font-size: 16px;
+	font-size: 1rem;
+	font-style: italic;
+}
+
+.post__thumbnail {
+	max-width: 1030px;
+	margin: 0 0 20px;
+	margin-bottom: 0 0 1.25rem;
+}
+
+.post__thumbnail img {
+	width: 100%;
+}
+
+.content a,
+.warning a,
+.authorbox__description a {
+	color: #f5821f;
+}
+
+.content a:hover,
+.warning a:hover,
+.authorbox__description a:hover {
+	color: #f5821f;
+	text-decoration: underline;
+}
+
+.content .alignnone {
+	display: block;
+	margin: 20px 0;
+	margin: 1.25rem 0;
+}
+
+.content .aligncenter {
+	display: block;
+	margin: 20px auto;
+	margin: 1.25rem auto;
+}
+
+.content .alignleft {
+	display: inline;
+	float: left;
+	margin: 5px 20px 20px 0;
+	margin: 0.3125rem 1.25rem 1.25rem 0;
+}
+
+.content .alignright {
+	display: inline;
+	float: right;
+	margin: 5px 0 20px 20px;
+	margin: 0.3125rem 0 1.25rem 1.25rem;
+}
+
+.content ul {
+	list-style: square;
+}
+
+.content ol {
+	list-style: decimal;
+}
+
+.content ul,
+.content ol {
+	margin: 0 0 20px 40px;
+}
+
+.content ul ul,
+.content ol ol,
+.content ol ul,
+.content ul ol {
+	margin: 0 0 0 40px;
+}
+
+.content li {
+	margin-bottom: 5px;
+}
+
+.post__footer {
+	margin-top: 20px;
+	margin-top: 1.25rem;
+}
+
+/* Post tags */
+.tags {
+	margin-bottom: 20px;
+	margin-bottom: 1.25rem;
+	font-size: 12px;
+	font-size: 0.75rem;
+	line-height: 1;
+	color: #fff;
+}
+
+.tags__list {
+	list-style: none;
+}
+
+.tags__item {
+	float: left;
+	margin: 0 6px 6px 0;
+	margin: 0 0.375rem 0.375rem 0;
+	text-transform: uppercase;
+	background: #2a2a2a;
+}
+
+.tags__item:hover {
+	background: #f5821f;
+}
+
+.tags__link,
+.tags__link:hover {
+	display: block;
+	padding: 10px 15px;
+}
+
+.tags__badge {
+	float: left;
+	width: 32px;
+	height: 32px;
+	padding: 8px;
+	margin-right: 6px;
+
+	background: #f5821f;
+
+	fill: #fff;
+}
+
+/* Table of Contents */
+.toc {
+	margin-bottom: 20px;
+	font-weight: 700;
+	color: #7a8288;
+	background: #fff;
+	border-color: #ebebeb;
+	border-style: solid;
+	border-top-width: 1px;
+	border-right-width: 1px;
+	border-bottom-width: 0;
+	border-left-width: 1px;
+}
+
+.toc__title {
+	padding: 5px 10px;
+	color: #fff;
+	text-transform: uppercase;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
+	background: #2a2a2a;
+}
+
+.toc__menu ul {
+	margin: 0;
+	list-style: none;
+}
+
+.toc__menu li li a {
+	padding-left: 25px;
+}
+
+.toc__menu li li li a {
+	padding-left: 45px;
+}
+
+.toc__menu li li li li a {
+	padding-left: 65px;
+}
+
+.toc__menu li li li li li a {
+	padding-left: 85px;
+}
+
+.toc__menu li li li li li li a {
+	padding-left: 105px;
+}
+
+.toc__menu li {
+	margin: 0;
+}
+
+.toc__menu a {
+	display: block;
+	padding: 5px 10px;
+
+	color: #f5821f;
+
+	border-bottom: 1px solid #ebebeb;
+}
+
+.toc__menu a:hover {
+	text-decoration: underline;
+}
+
+/* Author Box */
+.authorbox {
+	padding: 25px 0;
+	margin-bottom: 25px;
+	line-height: 1.5;
+	border-top: 1px solid #ebebeb;
+	border-bottom: 1px solid #ebebeb;
+}
+
+.authorbox__avatar {
+	float: left;
+	padding: 3px;
+	margin: 0 25px 0 0;
+	border: 1px solid #ebebeb;
+}
+
+.authorbox__header {
+	margin-bottom: 10px;
+}
+
+.authorbox__name {
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 700;
+}
+
+/* List content */
+.list__item {
+	padding-bottom: 20px;
+	padding-bottom: 1.25rem;
+	margin-bottom: 20px;
+	margin-bottom: 1.25rem;
+	border-bottom: 1px solid #ebebeb;
+}
+
+.list__header {
+	margin-bottom: 10px;
+	margin-bottom: 0.625rem;
+}
+
+.list__title {
+	font-size: 20px;
+	font-size: 1.25rem;
+}
+
+.list__meta {
+	margin-top: 5px;
+}
+
+.list__thumbnail {
+	float: left;
+	margin: 0 20px 0 0;
+}
+
+.list__thumbnail img {
+	width: 100%;
+	max-width: 235px;
+}
+
+.list__footer-readmore {
+	float: right;
+	margin-top: 10px;
+}
+
+/* Pagination */
+.pagination {
+	margin-top: 20px;
+}
+
+.pagination__item {
+	display: inline-block;
+	padding: 10px 15px;
+	font-weight: 700;
+	color: #000;
+	background: #f5f5f5;
+}
+
+.pagination__item:hover,
+.pagination__item--current {
+	color: #fff;
+
+	background: #f5821f;
+}
+
+/* Pager (prev/next links) navigation */
+.pager {
+	-webkit-justify-content: space-between;
+	justify-content: space-between;
+	padding-top: 25px;
+	padding-bottom: 25px;
+	margin-bottom: 25px;
+	border-bottom: 1px solid #ebebeb;
+}
+
+.pager__subtitle {
+	display: block;
+	margin-bottom: 5px;
+	font-weight: 700;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+.pager__title {
+	margin-bottom: 0;
+	overflow: hidden;
+	font-size: 13px;
+	font-size: 0.8125rem;
+}
+
+.pager__item {
+	-webkit-flex: 1 1 50%;
+	flex: 1 1 50%;
+	max-width: 48%;
+}
+
+.pager__item--next {
+	margin-left: auto;
+	text-align: right;
+}
+
+.pager__link {
+	display: block;
+}
+
+/* Images / Video */
+img {
+	width: auto\9;
+	/* ie8 */
+	max-width: 100%;
+	height: auto;
+	vertical-align: bottom;
+}
+
+iframe,
+embed,
+object,
+video {
+	max-width: 100%;
+}
+
+/* Table */
+/*table {
 	width: 100%;
 	margin-bottom: 20px;
 	margin-bottom: 1.25rem;
@@ -1039,590 +1042,677 @@ th {
 	font-weight: 700;
 }
 */
-	/* Forms */
-	input {
-		padding: 5px;
-		font-size: 12px;
-		vertical-align: middle;
-		background: #f5f5f5;
-		border: 1px solid #ebebeb;
-		transition: all .25s ease-in-out;
+/* Forms */
+input {
+	padding: 5px;
+	font-size: 12px;
+	vertical-align: middle;
+	background: #f5f5f5;
+	border: 1px solid #ebebeb;
+	transition: all 0.25s ease-in-out;
+}
+
+input[type="text"],
+input[type="email"],
+input[type="tel"],
+input[type="url"] {
+	width: 60%;
+}
+
+input[type="text"]:hover,
+input[type="email"]:hover,
+input[type="tel"]:hover,
+input[type="url"]:hover,
+textarea:hover {
+	border: 1px solid #aaa;
+}
+
+input[type="submit"],
+input[type="reset"] {
+	display: inline-block;
+	min-width: 150px;
+	padding: 10px 15px;
+	font-weight: 700;
+	color: #fff;
+	text-transform: uppercase;
+	cursor: pointer;
+	background: #2a2a2a;
+	border: 0;
+	transition: all 0.1s linear;
+	-webkit-appearance: none;
+}
+
+input[type="submit"]:hover,
+input[type="reset"]:hover {
+	background: #f5821f;
+}
+
+textarea {
+	width: 96%;
+	padding: 5px;
+	overflow: auto;
+	line-height: 1.5;
+	resize: vertical;
+	background: #f5f5f5;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Widgets */
+.widget {
+	margin-bottom: 25px;
+	overflow: hidden;
+}
+
+.widget:last-child {
+	margin-bottom: 0;
+}
+
+.widget__title {
+	position: relative;
+	padding-bottom: 5px;
+	font-size: 16px;
+	font-size: 1rem;
+	text-transform: uppercase;
+
+	border-bottom: 3px solid #f5821f;
+}
+
+.widget__item {
+	display: block;
+	padding: 5px 0;
+	border-bottom: 1px dotted #ebebeb;
+}
+
+.widget__item:first-child {
+	padding-top: 0;
+}
+
+.widget__counter--bubble {
+	display: inline-block;
+	padding: 0 6px;
+	font-size: 0.75rem;
+	color: #666;
+	text-align: center;
+	background: #ebebeb;
+	border-radius: 2em;
+}
+
+/* Search widget */
+.widget-search__form {
+	display: block;
+	padding: 5%;
+	margin: 0 auto;
+	background: #f5f5f5;
+}
+
+.widget-search__form .widget-search__submit {
+	display: none;
+}
+
+.widget-search__field {
+	position: relative;
+	display: block;
+	width: 90%;
+	padding: 8px;
+	margin: 0 auto;
+	font-size: 11px;
+	cursor: pointer;
+	background: #fff;
+	border: 1px solid #ebebeb;
+	border-radius: 0;
+	outline-offset: -2px;
+	transition: none;
+	-webkit-appearance: none;
+}
+
+.widget-search__field:active,
+.widget-search__field:focus {
+	cursor: text;
+}
+
+/* Social widget */
+.widget-social__item {
+	padding: 0;
+	border: 0;
+}
+
+.widget-social__link {
+	display: block;
+	margin: 0 0 8px;
+	white-space: normal;
+}
+
+.widget-social__link-icon {
+	margin: 0 5px 0 0;
+	vertical-align: middle;
+	fill: #fff;
+}
+
+/* Tags Widget */
+.widget-taglist__link {
+	display: inline-block;
+	margin: 0 4px 8px 0;
+	font-size: 12px;
+	text-transform: uppercase;
+}
+
+/* Languages Widget */
+.widget-languages__link {
+	display: block;
+}
+
+.widget-languages__link:hover .widget-languages__link-btn {
+	color: #fff;
+
+	background: #f5821f;
+}
+
+.widget-languages__link-btn {
+	display: inline-block;
+}
+
+/* Footer */
+.footer {
+	padding: 10px 25px;
+	font-size: 12px;
+	font-size: 0.75rem;
+	color: #999;
+	background: #2a2a2a;
+	border-top: 3px solid #999;
+}
+
+.footer__container {
+	-webkit-flex-flow: row wrap;
+	flex-flow: row wrap;
+	-webkit-justify-content: space-between;
+	justify-content: space-between;
+}
+
+.footer__links {
+	-webkit-order: 1;
+	order: 1;
+}
+
+.footer a {
+	color: #fff;
+}
+
+.footer a:hover {
+	text-decoration: underline;
+}
+
+/* Media Queries */
+@media screen and (max-width: 1475px) {
+	.container--outer {
+		width: 95%;
+	}
+}
+
+@media screen and (max-width: 900px) {
+	.container--outer {
+		width: 100%;
+		margin: 0 auto;
 	}
 
-	input[type=text],
-	input[type=email],
-	input[type=tel],
-	input[type=url] {
-		width: 60%;
+	.wrapper,
+	.logo {
+		padding: 20px;
 	}
 
-	input[type=text]:hover,
-	input[type=email]:hover,
-	input[type=tel]:hover,
-	input[type=url]:hover,
-	textarea:hover {
-		border: 1px solid #aaa;
-	}
-
-	input[type=submit],
-	input[type=reset] {
-		display: inline-block;
-		min-width: 150px;
-		padding: 10px 15px;
-		font-weight: 700;
-		color: #fff;
-		text-transform: uppercase;
-		cursor: pointer;
-		background: #2a2a2a;
-		border: 0;
-		transition: all .1s linear;
-		-webkit-appearance: none;
-	}
-
-	input[type=submit]:hover,
-	input[type=reset]:hover {
-		background: #f5821f;
-
-	}
-
-	textarea {
-		width: 96%;
-		padding: 5px;
-		overflow: auto;
-		line-height: 1.5;
-		resize: vertical;
-		background: #f5f5f5;
-		border: 1px solid rgba(0, 0, 0, .1);
-	}
-
-	/* Widgets */
 	.widget {
-		margin-bottom: 25px;
-		overflow: hidden;
-	}
-
-	.widget:last-child {
-		margin-bottom: 0;
-	}
-
-	.widget__title {
-		position: relative;
-		padding-bottom: 5px;
-		font-size: 16px;
-		font-size: 1rem;
-		text-transform: uppercase;
-
-		border-bottom: 3px solid #f5821f;
-
-	}
-
-	.widget__item {
-		display: block;
-		padding: 5px 0;
-		border-bottom: 1px dotted #ebebeb;
-	}
-
-	.widget__item:first-child {
-		padding-top: 0;
-	}
-
-	.widget__counter--bubble {
-		display: inline-block;
-		padding: 0 6px;
-		font-size: .75rem;
-		color: #666;
-		text-align: center;
-		background: #ebebeb;
-		border-radius: 2em;
-	}
-
-	/* Search widget */
-	.widget-search__form {
-		display: block;
-		padding: 5%;
-		margin: 0 auto;
-		background: #f5f5f5;
-	}
-
-	.widget-search__form .widget-search__submit {
-		display: none;
-	}
-
-	.widget-search__field {
-		position: relative;
-		display: block;
-		width: 90%;
-		padding: 8px;
-		margin: 0 auto;
-		font-size: 11px;
-		cursor: pointer;
-		background: #fff;
-		border: 1px solid #ebebeb;
-		border-radius: 0;
-		outline-offset: -2px;
-		transition: none;
-		-webkit-appearance: none;
-	}
-
-	.widget-search__field:active,
-	.widget-search__field:focus {
-		cursor: text;
-	}
-
-	/* Social widget */
-	.widget-social__item {
-		padding: 0;
-		border: 0;
-	}
-
-	.widget-social__link {
-		display: block;
-		margin: 0 0 8px;
-		white-space: normal;
-	}
-
-	.widget-social__link-icon {
-		margin: 0 5px 0 0;
-		vertical-align: middle;
-		fill: #fff;
-	}
-
-	/* Tags Widget */
-	.widget-taglist__link {
-		display: inline-block;
-		margin: 0 4px 8px 0;
-		font-size: 12px;
-		text-transform: uppercase;
-	}
-
-	/* Languages Widget */
-	.widget-languages__link {
-		display: block;
-	}
-
-	.widget-languages__link:hover .widget-languages__link-btn {
-		color: #fff;
-
-		background: #f5821f;
-
-	}
-
-	.widget-languages__link-btn {
-		display: inline-block;
-	}
-
-	/* Footer */
-	.footer {
-		padding: 10px 25px;
-		font-size: 12px;
-		font-size: .75rem;
-		color: #999;
-		background: #2a2a2a;
-		border-top: 3px solid #999;
+		margin-bottom: 20px;
 	}
 
 	.footer__container {
-		-webkit-flex-flow: row wrap;
-		flex-flow: row wrap;
-		-webkit-justify-content: space-between;
-		justify-content: space-between;
+		display: block;
 	}
 
 	.footer__links {
-		-webkit-order: 1;
-		order: 1;
+		padding-bottom: 8px;
+		padding-bottom: 0.5rem;
+		text-align: center;
 	}
 
-	.footer a {
-		color: #fff;
+	.footer__copyright {
+		text-align: center;
+	}
+}
+
+* {
+	transition-property: background-color, padding, margin, opacity, transform,
+		visibility !important;
+	transition-duration: 300ms;
+}
+
+@media screen and (max-width: 767px) {
+	.header__container {
+		display: flex;
+		flex-direction: column-reverse;
+		--icaps-2025-header-action-color: #b6c2cf;
+		--icaps-2025-header-text-color: #b6c2cf;
+		--icaps-2025-header-bg-color: #1d2125;
+		--icaps-2025-header-divider: #333c43;
+		/* Change this to 'none' to hide title */
+		--icaps-2025-display-title: inline-block;
 	}
 
-	.footer a:hover {
-		text-decoration: underline;
+	/* ─── Appbar ─────────────────────────────────────────────────────── */
+
+	nav.menu {
+		overflow-x: hidden;
+		height: 64px;
+		border-bottom: 1px solid var(--icaps-2025-header-divider);
+	}
+	nav.menu > .menu__btn {
+		height: 100%;
+		background-color: var(--icaps-2025-header-bg-color);
 	}
 
-	/* Media Queries */
-	@media screen and (max-width: 1475px) {
-		.container--outer {
-			width: 95%;
-		}
+	nav.menu > .menu__btn > .menu__btn-title {
+		font-family: "Segoe UI Symbol", "Arial", "Helvetica", sans-serif;
+		font-weight: 500;
+		font-size: 18px;
+		/* Adjusted for visual correctness */
+		transform: scaleX(1.1);
+		transform-origin: right;
+		color: var(--icaps-2025-header-action-color);
 	}
 
-	@media screen and (max-width: 900px) {
-		.container--outer {
-			width: 100%;
-			margin: 0 auto;
-		}
-
-		.wrapper,
-		.logo {
-			padding: 20px;
-		}
-
-		.widget {
-			margin-bottom: 20px;
-		}
-
-		.footer__container {
-			display: block;
-		}
-
-		.footer__links {
-			padding-bottom: 8px;
-			padding-bottom: 0.5rem;
-			text-align: center;
-		}
-
-		.footer__copyright {
-			text-align: center;
-		}
+	nav.menu > .menu__list,
+	nav.menu .submenu__list {
+		background-color: var(--icaps-2025-header-bg-color) !important;
+	}
+	nav.menu > .menu__list .menu__text,
+	nav.menu > .menu__list .menu__link .drop-icon {
+		color: var(--icaps-2025-header-text-color);
+		text-transform: capitalize;
+		font-weight: 400;
 	}
 
-	@media screen and (max-width: 767px) {
-		.wrapper {
-			display: block;
-		}
-
-		.sidebar {
-			float: none;
-			width: 100%;
-			margin: 0;
-		}
-
-		.logo {
-			text-align: center;
-		}
-
-		.logo__link {
-			margin: 0 auto;
-		}
-
-		.logo__title {
-			font-size: 20px;
-			font-size: 1.5rem;
-		}
-
-        .logo--mixed .logo__img {
-            max-width: 126px;
-            max-height: 126px;
-            padding:1.5px;
-        }
-
-		.sidebar {
-			margin-top: 20px;
-		}
+	nav.menu .menu__list {
+		transform: translateY(-16px);
+		opacity: 0;
+		transition-property: transform, opacity, visibility;
+		box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px,
+			rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;
+	}
+	nav.menu .menu__list--active {
+		opacity: 1;
+		transform: none;
 	}
 
-	@media screen and (max-width: 620px) {
+	/* ─── Logo ───────────────────────────────────────────────────────── */
 
-		input[type=text],
-		input[type=email],
-		input[type=tel],
-		input[type=url] {
-			width: 88%;
-		}
+	div.logo > .logo__link > .logo__item > .logo__img {
+		position: absolute;
+		top: 0;
+		left: 0;
+		margin: 12px 20px;
+		background-color: transparent;
+		filter: hue-rotate(180deg) invert(1);
+		height: 38px;
+	}
 
-		.logo__title {
-			font-size: 16px;
-			font-size: 1rem;
-		}
+	/* ─── Title ──────────────────────────────────────────────────────── */
 
-        .logo--mixed .logo__img {
-            max-width: 100px;
-            max-height: 100px;
-            padding:1px;
-        }
+	div.logo {
+		background-color: var(--icaps-2025-header-bg-color);
+		background-size: 100vw;
+		background-position: center;
+		background-attachment: fixed;
+		background-image: none !important;
+	}
 
-        .logo__tagline {
-            display: inline-block;
-            padding-top: 10px;
-            margin-top: 10px;
-            font-size: 11px;
-            font-size: .6875rem;
-            font-weight: 700;
-            line-height: 1;
-            color: rgba(35,31,32,1);
-        /* [ddh] adjust the color of the divider between the 
+	div.logo > .logo__link > .logo__text {
+		padding: 0;
+		background-color: transparent;
+		display: var(--icaps-2025-display-title);
+	}
+
+	div.logo > .logo__link > .logo__text > .logo__title {
+		font-weight: 400;
+		font-size: clamp(4vw, 1.4em, 1.8em);
+		color: var(--icaps-2025-header-text-color);
+	}
+	div.logo > .logo__link > .logo__text > .logo__tagline {
+		font-weight: 400;
+		font-size: 1em;
+		border-top: none;
+		opacity: 0.6;
+		color: var(--icaps-2025-header-text-color);
+		white-space: pre-line;
+		line-height: 1.25em;
+	}
+
+	/* ────────────────────────────────────────────────────────────────── */
+
+	.wrapper {
+		display: block;
+	}
+
+	.sidebar {
+		float: none;
+		width: 100%;
+		margin: 0;
+	}
+
+	.logo {
+		/* text-align: center; */
+	}
+
+	.logo__link {
+		margin: 0 auto;
+	}
+
+	.logo__title {
+		font-size: 20px;
+		font-size: 1.5rem;
+	}
+
+	.logo--mixed .logo__img {
+		max-width: 126px;
+		max-height: 126px;
+		padding: 1.5px;
+	}
+
+	.sidebar {
+		margin-top: 20px;
+	}
+}
+
+@media screen and (max-width: 620px) {
+	input[type="text"],
+	input[type="email"],
+	input[type="tel"],
+	input[type="url"] {
+		width: 88%;
+	}
+
+	.logo__title {
+		font-size: 16px;
+		font-size: 1rem;
+	}
+
+	.logo--mixed .logo__img {
+		max-width: 100px;
+		max-height: 100px;
+		padding: 1px;
+	}
+
+	.logo__tagline {
+		display: inline-block;
+		padding-top: 10px;
+		margin-top: 10px;
+		font-size: 11px;
+		font-size: 0.6875rem;
+		font-weight: 700;
+		line-height: 1;
+		color: rgba(35, 31, 32, 1);
+		/* [ddh] adjust the color of the divider between the 
          * $logoTitle2 text (=xx ICAPS)  and the logoSubtitle
          * (= location) 
          */
-		border-top: 1px solid rgba(35,31,32,1);
+		border-top: 1px solid rgba(35, 31, 32, 1);
 	}
 
-		.meta__item {
-			display: block;
-			margin-left: 0;
-		}
-
-		.authorbox {
-			text-align: center;
-		}
-
-		.authorbox__avatar {
-			display: inline-block;
-			float: none;
-			margin: 0 0 20px;
-		}
-
-		.pager {
-			display: block;
-		}
-
-		.pager__item {
-			min-width: 100%;
-			text-align: center;
-		}
-
-		.pager__item--prev {
-			padding-bottom: 25px;
-		}
-
-		.content ul,
-		.content ol {
-			margin: 0 0 20px 20px;
-		}
-
-		.content ul ul,
-		.content ol ol,
-		.content ol ul,
-		.content ul ol {
-			margin: 0 0 0 20px;
-		}
-
-		.list__thumbnail {
-			max-width: 80px;
-		}
-
-		.list__title {
-			font-size: 16px;
-			font-size: 1rem;
-		}
-
-		.list__lead {
-			font-size: 14px;
-			font-size: .875rem;
-		}
-
-		.list__meta {
-			display: block;
-			font-size: 11px;
-			font-size: .6875rem;
-		}
+	.meta__item {
+		display: block;
+		margin-left: 0;
 	}
 
-	/* Main menu */
-	.no-js .menu__btn {
-		display: none;
+	.authorbox {
+		text-align: center;
+	}
+
+	.authorbox__avatar {
+		display: inline-block;
+		float: none;
+		margin: 0 0 20px;
+	}
+
+	.pager {
+		display: block;
+	}
+
+	.pager__item {
+		min-width: 100%;
+		text-align: center;
+	}
+
+	.pager__item--prev {
+		padding-bottom: 25px;
+	}
+
+	.content ul,
+	.content ol {
+		margin: 0 0 20px 20px;
+	}
+
+	.content ul ul,
+	.content ol ol,
+	.content ol ul,
+	.content ul ol {
+		margin: 0 0 0 20px;
+	}
+
+	.list__thumbnail {
+		max-width: 80px;
+	}
+
+	.list__title {
+		font-size: 16px;
+		font-size: 1rem;
+	}
+
+	.list__lead {
+		font-size: 14px;
+		font-size: 0.875rem;
+	}
+
+	.list__meta {
+		display: block;
+		font-size: 11px;
+		font-size: 0.6875rem;
+	}
+}
+
+/* Main menu */
+.no-js .menu__btn {
+	display: none;
+}
+
+.menu__btn {
+	display: block;
+	width: 100%;
+	padding: 0;
+	font: inherit;
+	color: #fff;
+	background: #2a2a2a;
+	border: 0;
+	outline: 0;
+}
+
+.menu__btn-title {
+	position: relative;
+	display: block;
+	padding: 10px 15px;
+	padding: 0.625rem 0.9375rem;
+	font-weight: 700;
+	text-align: right;
+	text-transform: uppercase;
+	cursor: pointer;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
+}
+
+:focus > .menu__btn-title {
+	box-shadow: inset 0 0 1px 3px #f5821f;
+}
+
+button:not(:-moz-focusring):focus > .menu__btn-title {
+	box-shadow: none;
+}
+
+.menu__btn:focus,
+.menu__btn-title:focus {
+	outline: 0;
+}
+
+.js .menu__btn--active {
+	color: #f5821f;
+}
+
+.menu__list,
+.submenu__list {
+	list-style: none;
+	background: #2a2a2a;
+}
+
+.menu__item:hover > a {
+	color: #fff;
+}
+
+.menu__item:first-child {
+	border: 0;
+}
+
+.menu__item--active {
+	background: #f5821f;
+}
+
+.menu__link {
+	display: block;
+	padding: 10px 15px;
+	padding: 0.625rem 0.9375rem;
+	font-weight: 700;
+	color: #fff;
+	text-transform: uppercase;
+}
+
+.menu__list .menu__item .submenu__list {
+	background: #2a2a2a;
+	visibility: hidden;
+	opacity: 0;
+	position: absolute;
+	max-width: 15rem;
+	transition: all 0.5s ease;
+
+	border-top: 5px solid #f5821f;
+
+	display: none;
+}
+
+.menu__item.menu__dropdown input[type="checkbox"] {
+	display: none;
+}
+
+.menu__list .menu__item:hover > .submenu__list,
+.menu__list .menu__item:focus-within > .submenu__list,
+.menu__list .menu__item .submenu__list:hover,
+.menu__list .menu__item .submenu__list:focus {
+	visibility: visible;
+	opacity: 1;
+	display: block;
+}
+
+.menu__link:hover {
+	color: #fff;
+}
+
+.js .menu__list {
+	position: absolute;
+	z-index: 1;
+	width: 100%;
+	visibility: hidden;
+	-webkit-transform: scaleY(0);
+	transform: scaleY(0);
+	-webkit-transform-origin: top left;
+	transform-origin: top left;
+}
+
+.js .menu__list--active {
+	visibility: visible;
+	border-top: 1px solid rgba(255, 255, 255, 0.1);
+	border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+	-webkit-transform: scaleY(1);
+	transform: scaleY(1);
+}
+
+highlightColor .menu__list--transition {
+	transition: visibility 0.15s ease, transform 0.15s ease,
+		-webkit-transform 0.15s ease;
+}
+
+@media screen and (min-width: 767px) {
+	.menu {
+		border-bottom: 5px solid #f5821f;
 	}
 
 	.menu__btn {
-		display: block;
-		width: 100%;
-		padding: 0;
-		font: inherit;
-		color: #fff;
-		background: #2a2a2a;
-		border: 0;
-		outline: 0;
-	}
-
-	.menu__btn-title {
-		position: relative;
-		display: block;
-		padding: 10px 15px;
-		padding: 0.625rem 0.9375rem;
-		font-weight: 700;
-		text-align: right;
-		text-transform: uppercase;
-		cursor: pointer;
-		-webkit-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		-o-user-select: none;
-		user-select: none;
-	}
-
-	:focus>.menu__btn-title {
-	  box-shadow: inset 0 0 1px 3px #f5821f;
-
-	}
-
-	button:not(:-moz-focusring):focus>.menu__btn-title {
-		box-shadow: none;
-	}
-
-	.menu__btn:focus,
-	.menu__btn-title:focus {
-		outline: 0;
-	}
-
-	.js .menu__btn--active {
-	  color: #f5821f;
-
+		display: none;
 	}
 
 	.menu__list,
-	.submenu__list {
-		list-style: none;
-		background: #2a2a2a;
-	}
-
-	.menu__item:hover>a {
-		color: #fff;
-	}
-
-	.menu__item:first-child {
+	.js .menu__list {
+		position: relative;
+		display: -webkit-flex;
+		display: flex;
+		-webkit-flex-wrap: wrap;
+		flex-wrap: wrap;
+		visibility: visible;
 		border: 0;
+		-webkit-transform: none;
+		transform: none;
 	}
 
-	.menu__item--active {
-	  background: #f5821f;
-
+	.menu__item {
+		border-left: 1px solid rgba(255, 255, 255, 0.1);
 	}
+}
 
-	.menu__link {
-		display: block;
-		padding: 10px 15px;
-		padding: 0.625rem 0.9375rem;
-		font-weight: 700;
-		color: #fff;
-		text-transform: uppercase;
-	}
-
-	.menu__list .menu__item .submenu__list {
-		background: #2a2a2a;
-		visibility: hidden;
-		opacity: 0;
+@media screen and (max-width: 767px) {
+	.menu__item.menu__dropdown .drop-icon {
 		position: absolute;
-		max-width: 15rem;
-		transition: all 0.5s ease;
+		right: 1rem;
+		top: auto;
+	}
 
-		border-top: 5px solid #f5821f;
-
+	.menu__item.menu__dropdown input[type="checkbox"] + .submenu__list {
 		display: none;
 	}
 
-	.menu__item.menu__dropdown input[type="checkbox"] {
-		display: none;
-	}
-
-	.menu__list .menu__item:hover>.submenu__list,
-	.menu__list .menu__item:focus-within>.submenu__list,
-	.menu__list .menu__item .submenu__list:hover,
-	.menu__list .menu__item .submenu__list:focus {
+	.menu__item.menu__dropdown input[type="checkbox"]:checked + .submenu__list {
+		border: none;
+		padding-left: 20px;
 		visibility: visible;
 		opacity: 1;
 		display: block;
+		position: relative;
+		max-width: 100%;
 	}
+}
 
-	.menu__link:hover {
-		color: #fff;
-	}
-
-	.js .menu__list {
+@media screen and (max-width: 620px) {
+	.menu__item.menu__dropdown .drop-icon {
 		position: absolute;
-		z-index: 1;
-		width: 100%;
-		visibility: hidden;
-		-webkit-transform: scaleY(0);
-		transform: scaleY(0);
-		-webkit-transform-origin: top left;
-		transform-origin: top left;
+		right: 1rem;
+		top: auto;
 	}
 
-	.js .menu__list--active {
+	.menu__item.menu__dropdown input[type="checkbox"] + .submenu__list {
+		display: none;
+	}
+
+	.menu__item.menu__dropdown input[type="checkbox"]:checked + .submenu__list {
+		border: none;
+		padding-left: 20px;
 		visibility: visible;
-		border-top: 1px solid rgba(255, 255, 255, 0.1);
-		border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-		-webkit-transform: scaleY(1);
-		transform: scaleY(1);
+		opacity: 1;
+		display: block;
+		position: relative;
+		max-width: 100%;
 	}
-
-	highlightColor .menu__list--transition {
-		transition: visibility 0.15s ease, transform 0.15s ease,
-			-webkit-transform 0.15s ease;
-	}
-
-	@media screen and (min-width: 767px) {
-		.menu {
-		    border-bottom: 5px solid #f5821f;
-
-		}
-
-		.menu__btn {
-			display: none;
-		}
-
-		.menu__list,
-		.js .menu__list {
-			position: relative;
-			display: -webkit-flex;
-			display: flex;
-			-webkit-flex-wrap: wrap;
-			flex-wrap: wrap;
-			visibility: visible;
-			border: 0;
-			-webkit-transform: none;
-			transform: none;
-		}
-
-		.menu__item {
-			border-left: 1px solid rgba(255, 255, 255, 0.1);
-		}
-	}
-
-	@media screen and (max-width: 767px) {
-		.menu__item.menu__dropdown .drop-icon {
-			position: absolute;
-			right: 1rem;
-			top: auto;
-		}
-
-		.menu__item.menu__dropdown input[type="checkbox"]+.submenu__list {
-			display: none;
-		}
-
-		.menu__item.menu__dropdown input[type="checkbox"]:checked+.submenu__list {
-			border: none;
-			padding-left: 20px;
-			visibility: visible;
-			opacity: 1;
-			display: block;
-			position: relative;
-			max-width: 100%;
-		}
-	}
-
-	@media screen and (max-width: 620px) {
-		.menu__item.menu__dropdown .drop-icon {
-			position: absolute;
-			right: 1rem;
-			top: auto;
-		}
-
-		.menu__item.menu__dropdown input[type="checkbox"]+.submenu__list {
-			display: none;
-		}
-
-		.menu__item.menu__dropdown input[type="checkbox"]:checked+.submenu__list {
-			border: none;
-			padding-left: 20px;
-			visibility: visible;
-			opacity: 1;
-			display: block;
-			position: relative;
-			max-width: 100%;
-		}
-	}
-
-	#banner-main {
-		background-image: url('/img/banner_crop.jpg');
-		background-attachment: fixed;
-		background-repeat: no-repeat;
-		background-position: center 0em;
-		background-size: 1080px;
-
-		padding-top: 10em;
-        min-height: 160px;
-
-	}
+}

--- a/themes/mainroad/layouts/partials/menu.html
+++ b/themes/mainroad/layouts/partials/menu.html
@@ -1,82 +1,78 @@
 {{- if .Site.Menus.main }}
 <nav class="menu">
   <button class="menu__btn" aria-haspopup="true" aria-expanded="false" tabindex="0">
-    <span class="menu__btn-title" tabindex="-1">{{ T "menu_label" }}</span>
+    <span class="menu__btn-title" tabindex="-1">☰</span>
   </button>
   <ul class="menu__list">
     {{- $currentNode := . }}
     {{- range .Site.Menus.main }}
     {{- if .Name }}
-    
-    
     {{- if .HasChildren }}
     <li class="menu__item menu__dropdown{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
       <a class="menu__link" href="{{ .URL }}">
         {{ .Pre }}
-        <span class="menu__text">{{ .Name }}</span>
+        <span class="menu__text">
+          {{ .Name }}</span>
         <label class="drop-icon" for="{{ .Name }}">▾</label>
         {{ .Post }}
       </a>
       <input type="checkbox" id="{{ .Name }}">
       <ul class="submenu__list">
         {{ range .Children }}
-        	{{- if .HasChildren }}
-        	<li class="menu__item menu__dropdown{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
-		      <a class="menu__link" href="{{ .URL }}">
-			{{ .Pre }}
-			<span class="menu__text">{{ .Name }}</span>
-			<label class="drop-icon" for="{{ .Name }}">▾</label>
-			{{ .Post }}
-		      </a>
-		      <input type="checkbox" id="{{ .Name }}">
-		      <ul class="submenu__list">
-			{{ range .Children }}
-        			<li class="menu__item{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
-				  <a class="menu__link" href="{{ .URL }}">
-				    {{ .Pre }}
-				    <span class="menu__text">{{ .Name }}</span>
-				    {{ .Post }}
-				  </a>
-				  </li>
-			  {{ end }}
-			</ul>
-		</li>          
-        	
-        	
-        	{{- else }}
-        
-		<li class="menu__item{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
-			  <a class="menu__link" href="{{ .URL }}">
-			    {{ .Pre }}
-			    <span class="menu__text">{{ .Name }}</span>
-			    {{ .Post }}
-			  </a>
-		</li>
-          
-          	{{ end }}
-          
+        {{- if .HasChildren }}
+        <li class="menu__item menu__dropdown{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
+          <a class="menu__link" href="{{ .URL }}">
+            {{ .Pre }}
+            <span class="menu__text">
+              {{ .Name }}</span>
+            <label class="drop-icon" for="{{ .Name }}">▾</label>
+            {{ .Post }}
+          </a>
+          <input type="checkbox" id="{{ .Name }}">
+          <ul class="submenu__list">
+            {{ range .Children }}
+            <li class="menu__item{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
+              <a class="menu__link" href="{{ .URL }}">
+                {{ .Pre }}
+                <span class="menu__text">
+                  {{ .Name }}</span>
+                {{ .Post }}
+              </a>
+            </li>
+            {{ end }}
+          </ul>
+        </li>
+        {{- else }}
+
+        <li class="menu__item{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
+          <a class="menu__link" href="{{ .URL }}">
+            {{ .Pre }}
+            <span class="menu__text">
+              {{ .Name }}</span>
+            {{ .Post }}
+          </a>
+        </li>
+        {{ end }}
         {{ end }}
       </ul>
     </li>
-    
-    
     {{- else }}
-    
-    
+
+
     <li class="menu__item{{ if or ($currentNode.IsMenuCurrent "main" .) ($currentNode.HasMenuCurrent "main" .) }} menu__item--active{{ end }}">
       <a class="menu__link" href="{{ .URL }}">
         {{ .Pre }}
-          <span class="menu__text">{{ .Name }}</span>
+        <span class="menu__text">
+          {{ .Name }}</span>
         {{ .Post }}
       </a>
     </li>
-    
-    
     {{- end }}
     {{- end }}
     {{- end }}
   </ul>
 </nav>
+
 {{ else -}}
 <div class="divider"></div>
 {{- end }}


### PR DESCRIPTION
Shrunk title for mobile screens. It dynamically resizes based on screen width.
Moved logo and menu button to the top.
Currently, the title gets shown for every single screen. Suggested to show only for the home page.

Below is a screenshot of the layout. Changes are 95% CSS.

![spaaaacccee github io_icaps25 github io_home_(Galaxy S22)](https://github.com/user-attachments/assets/7586c715-3baa-41c0-8f9e-b80320d371ed)
